### PR TITLE
Return color/shape/texture names in world models

### DIFF
--- a/shapeworld/world/color.py
+++ b/shapeworld/world/color.py
@@ -27,7 +27,7 @@ class Color(object):
         return isinstance(other, Color) and self.name == other.name
 
     def model(self):
-        return {'name': str(self), 'rgb': list(self.rgb), 'shade': self.shade}
+        return {'name': str(self.name), 'rgb': list(self.rgb), 'shade': self.shade}
 
     @staticmethod
     def from_model(model):

--- a/shapeworld/world/shape.py
+++ b/shapeworld/world/shape.py
@@ -26,7 +26,7 @@ class Shape(object):
         raise NotImplementedError
 
     def model(self):
-        return {'name': str(self), 'size': self.size.model()}
+        return {'name': str(self.name), 'size': self.size.model()}
 
     @staticmethod
     def from_model(model):

--- a/shapeworld/world/texture.py
+++ b/shapeworld/world/texture.py
@@ -13,7 +13,7 @@ class Texture(object):
         raise NotImplementedError
 
     def model(self):
-        return {'name': str(self)}
+        return {'name': str(self.name)}
 
     @staticmethod
     def from_model(model):


### PR DESCRIPTION
Currently entities in the world model look like:

```js
    {'center': {'x': 0.3753625138085587, 'y': 0.8923824286642166},
     'color': {'name': '<shapeworld.world.color.Color object at 0x108d603f0>',
      'rgb': [1.0, 0.0, 1.0],
      'shade': -0.1235934130783174},
     'id': 4,
     'rotation': 0.17237669687779344,
     'shape': {'name': '<shapeworld.world.shape.SemicircleShape object at 0x105e6d518>',
      'size': {'x': 0.11691908208874921, 'y': 0.058459541044374605}},
     'texture': {'name': '<shapeworld.world.texture.SolidTexture object at 0x108d29150>'}
```

this fixes the `name`s of color/shape/texture:

```js
    {'center': {'x': 0.3753625138085587, 'y': 0.8923824286642166},
     'color': {'name': 'green',
      'rgb': [1.0, 0.0, 1.0],
      'shade': -0.1235934130783174},
     'id': 4,
     'rotation': 0.17237669687779344,
     'shape': {'name': 'rectangle',
      'size': {'x': 0.11691908208874921, 'y': 0.058459541044374605}},
     'texture': {'name': 'solid'}
```