### PR TITLE
Minor fixes to ace functionality

### DIFF
--- a/shapeworld/realizers/dmrs/realizer.py
+++ b/shapeworld/realizers/dmrs/realizer.py
@@ -283,7 +283,8 @@ class DmrsRealizer(CaptionRealizer):
         caption_strings = [line for line in stdout_data if line != '']
         for n in none_indices:
             caption_strings.insert(n, '')
-        assert len(caption_strings) == len(captions), stdout_data + '\n' + stderr_data
+        assert len(caption_strings) == len(captions), \
+                '\n'.join(stdout_data) + '\n' + '\n'.join(stderr_data)
         return caption_strings
 
     def attribute_dmrs(self, attribute):

--- a/shapeworld/realizers/dmrs/realizer.py
+++ b/shapeworld/realizers/dmrs/realizer.py
@@ -1,6 +1,7 @@
 import copy
 import json
 import os
+import stat
 import platform
 import re
 import subprocess
@@ -21,10 +22,14 @@ def prepare_ace():
         else:
             assert False
         assert os.path.isfile(os.path.join(directory, 'resources', 'ace_{}.gz'.format(system)))
+        ace_path = os.path.join(directory, 'resources', 'ace')
         import gzip
         with gzip.open(os.path.join(directory, 'resources', 'ace_{}.gz'.format(system)), 'rb') as gzip_filehandle:
-            with open(os.path.join(directory, 'resources', 'ace'), 'wb') as filehandle:
+            with open(ace_path, 'wb') as filehandle:
                 filehandle.write(gzip_filehandle.read())
+        # Make executable
+        st = os.stat(ace_path)
+        os.chmod(ace_path, st.st_mode | stat.S_IEXEC)
 
 
 def prepare_grammar(language):


### PR DESCRIPTION
Fixes:

1. When `ace` fails, forming the `AssertionError` message creates an unhelpful `TypeError` because `stdout_data` and `stderr_data` are lists, not strings

```
Traceback (most recent call last):
  File "test.py", line 5, in <module>
    generated = dataset.generate(n=128, mode='train', include_model=True)
  File "/local/scratch/jlm95/ShapeWorld/shapeworld/dataset.py", line 995, in generate
    captions = self.caption_realizer.realize(captions=captions)
  File "/local/scratch/jlm95/ShapeWorld/shapeworld/realizers/dmrs/realizer.py", line 286, in
realize
    assert len(caption_strings) == len(captions), stdout_data + '\n' + stderr_data
TypeError: can only concatenate list (not "str") to list
```

2. The `ace` created on first use is not executable by default, which results in `PermissionError`.