### PR TITLE
Update to batch_records and README addition

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,16 @@ dataset = Dataset.create(dtype='agreement', name='multishape', config='examples/
 generated = tf_util.batch_records(dataset=dataset, mode='train', batch_size=128)
 ```
 
+The `generated` Tensor cannot be immediately evaluated as it requires the Tensorflow graph to start shard reading queues. Basic data reading can be performed as:
 
+```python
+with tf.Session() as session:
+	coordinator = tf.train.Coordinator()
+	queue_threads = tf.train.start_queue_runners(sess=session, coord=coordinator)
+	batch = session.run(generated)
+	coordinator.request_stop()
+	coordinator.join(threads=queue_threads)
+```
 
 ## CLEVR and NLVR interface
 

--- a/shapeworld/tf_util.py
+++ b/shapeworld/tf_util.py
@@ -59,7 +59,6 @@ def batch_records(dataset, mode, batch_size):
         records, sequence_records = read_records(dataset=dataset, mode=mode)
         if not isinstance(dataset, LoadedDataset) or dataset.random_sampling:
             if 'alternatives' in records:
-                print('check A')
                 sample = tf.cast(x=tf.floor(x=tf.multiply(x=tf.cast(x=records['alternatives'], dtype=tf.float32), y=tf.random_uniform(shape=()))), dtype=tf.int32)
                 for value_name, sequence_record in sequence_records.items():
                     records[value_name] = sequence_record[sample]
@@ -67,15 +66,12 @@ def batch_records(dataset, mode, batch_size):
             batch = tf.train.shuffle_batch(tensors=records, batch_size=batch_size, capacity=(batch_size * 50), min_after_dequeue=(batch_size * 10), num_threads=1)
         else:
             if 'alternatives' in records:
-                print('check B')
                 for value_name, sequence_record in sequence_records.items():
                     records[value_name] = sequence_record[0]
                 records.pop('alternatives')
             batch = tf.train.batch(tensors=records, batch_size=batch_size, num_threads=1, capacity=(batch_size * 50))
-        for value_name, value_type in dataset.values.items():
-            if value_name=='alternatives':
-                break
-            if dataset.pixel_noise_stddev > 0.0 and value_type == 'world':
+        for value_name, value_type in batch.items():
+            if dataset.pixel_noise_stddev > 0.0 and value_name == 'world':
                 noise = tf.truncated_normal(shape=((batch_size,) + dataset.world_shape()), mean=0.0, stddev=dataset.pixel_noise_stddev)
                 batch[value_name] = tf.clip_by_value(t=(batch[value_name] + noise), clip_value_min=0.0, clip_value_max=1.0)
             elif value_type == 'int' or value_type == 'vector(int)' or value_type in dataset.vocabularies:

--- a/shapeworld/tf_util.py
+++ b/shapeworld/tf_util.py
@@ -1,7 +1,6 @@
 import tensorflow as tf
 from shapeworld import util
 from shapeworld.dataset import LoadedDataset
-import pdb
 
 options = tf.python_io.TFRecordOptions(compression_type=tf.python_io.TFRecordCompressionType.GZIP)
 
@@ -71,7 +70,8 @@ def batch_records(dataset, mode, batch_size):
                 records.pop('alternatives')
             batch = tf.train.batch(tensors=records, batch_size=batch_size, num_threads=1, capacity=(batch_size * 50))
         for value_name, value_type in batch.items():
-            if dataset.pixel_noise_stddev > 0.0 and value_name == 'world':
+            value_type, _ = util.alternatives_type(value_type=dataset.values[value_name])
+            if dataset.pixel_noise_stddev > 0.0 and value_type == 'world':
                 noise = tf.truncated_normal(shape=((batch_size,) + dataset.world_shape()), mean=0.0, stddev=dataset.pixel_noise_stddev)
                 batch[value_name] = tf.clip_by_value(t=(batch[value_name] + noise), clip_value_min=0.0, clip_value_max=1.0)
             elif value_type == 'int' or value_type == 'vector(int)' or value_type in dataset.vocabularies:


### PR DESCRIPTION
* Fix the error in tf_util in batch_records to correctly iterate through the batch object.
* The call to util.alternatives_type now uses a lookup to `dataset.values[value_name]` as this is not a Tensor as `value_type` now is. 
* Added the example usage from the filed Issue for usage of the `generated` batch

